### PR TITLE
🐛 `parse()` 系関数の実行例を修正

### DIFF
--- a/articles/bd264fa884e026.md
+++ b/articles/bd264fa884e026.md
@@ -1448,10 +1448,10 @@ import * as z from "zod";
 // String型のスキーマ
 const StringSchema = z.string();
 
-const result = StringSchema.parse("fish"); // ✅ 検証に成功
+const result = StringSchema.safeParse("fish"); // ✅ 検証に成功
 console.log(result); // { success: true, data: "fish" }
 
-const result = StringSchema.parse(12); // ❌ 検証に失敗
+const result = StringSchema.safeParse(12); // ❌ 検証に失敗
 console.log(result); // { success: false, data: ZodError }
 ```
 
@@ -1480,7 +1480,7 @@ const HelloSchema = z.string().refine(async (val) => val === "hello");
   const result = await HelloSchema.safeParseAsync("hello"); // ✅ 検証に成功します
   console.log(result); // { success: true, data: "hello" }
 
-  const result = await HelloSchema.parseAsync("world"); // ❌ 検証に失敗します
+  const result = await HelloSchema.safeParseAsync("world"); // ❌ 検証に失敗します
   console.log(result); // { success: false, error: ZodError }
 })();
 


### PR DESCRIPTION
実行例に記述ミスを見つけたので修正の PR を出しておきます。

- `safeParse()` の実行例で `parse()` を実行している
  https://github.com/uttk/zenn-contents/blob/f60f0aa0c255e53571795890f3f52ebc88918959/articles/bd264fa884e026.md?plain=1#L1451-L1455
- `safeParseAsync()` の実行例で `parseAsync()` を実行している
  https://github.com/uttk/zenn-contents/blob/f60f0aa0c255e53571795890f3f52ebc88918959/articles/bd264fa884e026.md?plain=1#L1483-L1484